### PR TITLE
feat: add pagination support to campus list and user audit logs

### DIFF
--- a/services/campus-service/src/interfaces/dto/query-campus.dto.ts
+++ b/services/campus-service/src/interfaces/dto/query-campus.dto.ts
@@ -1,0 +1,24 @@
+import { IsOptional, IsString, IsEnum, IsNumber, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { CampusStatus } from '@eduhub/shared';
+
+export class QueryCampusDto {
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @IsOptional()
+  @IsEnum(CampusStatus)
+  status?: CampusStatus;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  page_size?: number = 20;
+
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+}

--- a/services/user-service/src/interfaces/controllers/user.controller.ts
+++ b/services/user-service/src/interfaces/controllers/user.controller.ts
@@ -386,8 +386,10 @@ export class UserController {
   @ApiParam({ name: 'id', type: 'number', description: 'User ID', example: 123 })
   @ApiQuery({ name: 'from', required: false, type: 'string', description: 'Start date (ISO 8601)', example: '2024-01-01' })
   @ApiQuery({ name: 'to', required: false, type: 'string', description: 'End date (ISO 8601)', example: '2024-01-31' })
-  @ApiResponse({ 
-    status: HttpStatus.OK, 
+  @ApiQuery({ name: 'page_size', required: false, type: 'number', description: 'Items per page (max 100)', example: 20 })
+  @ApiQuery({ name: 'cursor', required: false, type: 'string', description: 'Cursor for pagination', example: 'eyBpZDogMSB9' })
+  @ApiResponse({
+    status: HttpStatus.OK,
     description: 'Change history retrieved successfully',
     schema: {
       type: 'object',
@@ -405,9 +407,9 @@ export class UserController {
                   changed_at: { type: 'string', format: 'date-time', example: '2024-01-01T12:00:00.000Z' },
                   changed_by: { type: 'number', example: 1 },
                   action: { type: 'string', example: 'UPDATE' },
-                  diff: { 
-                    type: 'object', 
-                    example: { 
+                  diff: {
+                    type: 'object',
+                    example: {
                       email: { old: 'old@example.com', new: 'new@example.com' },
                       role: { old: 'Teacher', new: 'Senior Teacher' }
                     }
@@ -415,7 +417,9 @@ export class UserController {
                   request_id: { type: 'string', example: 'req-123' }
                 }
               }
-            }
+            },
+            next_cursor: { type: 'string', nullable: true, example: 'eyBpZDogMSB9' },
+            total: { type: 'number', example: 42 }
           }
         }
       }
@@ -426,21 +430,25 @@ export class UserController {
     @Param('id', ParseIntPipe) userId: number,
     @Headers('X-Org-Id') orgId: string,
     @Query('from') from?: string,
-    @Query('to') to?: string
+    @Query('to') to?: string,
+    @Query('page_size', ParseIntPipe) pageSize: number = 20,
+    @Query('cursor') cursor?: string
   ): Promise<ApiResponseType<any>> {
     if (!orgId) {
       orgId = '1'; // Default org_id for testing
     }
-    const changes = await this.userService.getChangeHistory(userId, parseInt(orgId), from, to);
+    const result = await this.userService.getChangeHistory(userId, parseInt(orgId), from, to, pageSize, cursor);
 
     return ResponseHelper.found({
-      items: changes.map(change => ({
+      items: result.items.map(change => ({
         changed_at: change.created_at,
         changed_by: change.actor_user_id,
         action: change.action,
         diff: change.diff_json,
         request_id: change.request_id
-      }))
+      })),
+      next_cursor: result.next_cursor,
+      total: result.total
     }, '变更历史获取成功');
   }
 }


### PR DESCRIPTION
## Summary
- add QueryCampusDto and implement filtering & cursor-based pagination for campus list
- extend user change history with page_size and cursor parameters

## Testing
- `npm test` *(fails: turbo: not found)*
- `npm install turbo` *(fails: request to http://ued.zuoyebang.cc/yocto-queue/-/yocto-queue-0.1.0.tgz failed, reason: socket hang up)*

------
https://chatgpt.com/codex/tasks/task_e_68b04fd49d2083339579310616ec3828