### PR TITLE
test: add billing service health endpoint tests

### DIFF
--- a/api-tests/jest/billing-health.spec.ts
+++ b/api-tests/jest/billing-health.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { FastifyInstance } from 'fastify';
+import { HealthController } from '../../services/billing-service/src/interfaces/controllers/health.controller';
+
+describe('Billing Service HealthController', () => {
+  let app: INestApplication;
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    app = module.createNestApplication(new FastifyAdapter());
+    app.setGlobalPrefix('core');
+    await app.init();
+    server = app.getHttpAdapter().getInstance();
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /core/health returns service ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/core/health' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toEqual(
+      expect.objectContaining({
+        status: 'ok',
+        service: 'billing-service',
+      })
+    );
+  });
+
+  it('GET /core/health/ready returns service ready', async () => {
+    const res = await server.inject({ method: 'GET', url: '/core/health/ready' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toEqual(
+      expect.objectContaining({
+        status: 'ready',
+        service: 'billing-service',
+      })
+    );
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/api-tests/jest/**/*.spec.ts'],
+  moduleNameMapper: {
+    '^@eduhub/shared$': '<rootDir>/libs/shared/src',
+    '^@eduhub/shared/(.*)$': '<rootDir>/libs/shared/src/$1'
+  },
+  maxWorkers: 1,
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json'
+    }
+  }
+};

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "isolatedModules": false,
+    "noEmit": true,
+    "paths": {
+      "@eduhub/shared": ["libs/shared/src"],
+      "@eduhub/shared/*": ["libs/shared/src/*"]
+    }
+  },
+  "include": ["api-tests/jest/**/*.ts", "services/**/*.ts", "libs/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- configure Jest and TypeScript for API tests
- add health endpoint tests for billing service

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b15da687288333b47a9cb2c00dafab